### PR TITLE
🔒 Add noopener and noreferrer to window.open

### DIFF
--- a/src/components/commands/Blog.tsx
+++ b/src/components/commands/Blog.tsx
@@ -27,7 +27,7 @@ const Blog: React.FC<BlogProps> = ({ blog }) => {
   // "blog read <slug>" — open post in new tab
   useEffect(() => {
     if (rerender && subCmd === 'read' && slugArg) {
-      window.open(`/blog/${slugArg}/`, '_blank');
+      window.open(`/blog/${slugArg}/`, '_blank', 'noopener,noreferrer');
     }
   }, [rerender]);
 

--- a/src/components/commands/Projects.tsx
+++ b/src/components/commands/Projects.tsx
@@ -27,7 +27,7 @@ const Projects: React.FC<ProjectsProps> = ({ projects }) => {
       if (project) {
         const url = project.links.find((l) => l.href.startsWith('http'))?.href;
         if (url) {
-          window.open(url, '_blank');
+          window.open(url, '_blank', 'noopener,noreferrer');
         }
       }
     }

--- a/src/components/commands/Socials.tsx
+++ b/src/components/commands/Socials.tsx
@@ -11,7 +11,7 @@ const Socials: React.FC = () => {
   useEffect(() => {
     if (rerender && subCmd === 'go' && !isNaN(targetNum)) {
       const social = SOCIALS[targetNum - 1];
-      if (social) window.open(social.url, '_blank');
+      if (social) window.open(social.url, '_blank', 'noopener,noreferrer');
     }
   }, [rerender]);
 


### PR DESCRIPTION
🎯 **What:** Fixed missing `noopener` and `noreferrer` security features in `window.open` calls.
⚠️ **Risk:** Malicious target pages could potentially use `window.opener` to redirect the original page to a phishing site or perform other unauthorized actions (tabnabbing).
🛡️ **Solution:** Updated all `window.open(url, '_blank')` calls to include `'noopener,noreferrer'` in the features string. This was applied to `src/components/commands/Projects.tsx`, `src/components/commands/Socials.tsx`, and `src/components/commands/Blog.tsx`.

---
*PR created automatically by Jules for task [6754500471346508218](https://jules.google.com/task/6754500471346508218) started by @joshuam1008*