### PR TITLE
🧪 [testing improvement] Add unit tests for applyTheme function

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "check": "astro check"
+    "check": "astro check",
+    "test": "node --experimental-strip-types --test src/**/*.test.ts"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.6",

--- a/src/components/commands/Themes.tsx
+++ b/src/components/commands/Themes.tsx
@@ -1,19 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import { termContext } from '../termContext';
-
-export const THEMES = [
-  { name: 'green',   label: 'Green on Black (default)', swatch: '#39d353' },
-  { name: 'amber',   label: 'Amber on Black',           swatch: '#ffb000' },
-  { name: 'dracula', label: 'Dracula',                  swatch: '#bd93f9' },
-  { name: 'matrix',  label: 'Matrix',                   swatch: '#00ff41' },
-] as const;
-
-export type ThemeName = (typeof THEMES)[number]['name'];
-
-export function applyTheme(name: ThemeName) {
-  document.documentElement.setAttribute('data-theme', name);
-  localStorage.setItem('terminal-theme', name);
-}
+import { applyTheme, THEMES, type ThemeName } from '../../lib/theme';
 
 const Themes: React.FC = () => {
   const { arg, rerender } = useContext(termContext);

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,49 @@
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { applyTheme, THEMES } from './theme.ts';
+
+describe('applyTheme', () => {
+  let mockDocument: any;
+  let mockLocalStorage: any;
+
+  beforeEach(() => {
+    mockDocument = {
+      documentElement: {
+        setAttribute: (name: string, value: string) => {
+          mockDocument.documentElement.attributes[name] = value;
+        },
+        attributes: {} as Record<string, string>,
+      },
+    };
+
+    mockLocalStorage = {
+      store: {} as Record<string, string>,
+      setItem: (key: string, value: string) => {
+        mockLocalStorage.store[key] = value;
+      },
+    };
+
+    // @ts-ignore
+    global.document = mockDocument;
+    // @ts-ignore
+    global.localStorage = mockLocalStorage;
+  });
+
+  test('should set data-theme attribute on documentElement', () => {
+    applyTheme('dracula');
+    assert.strictEqual(mockDocument.documentElement.attributes['data-theme'], 'dracula');
+  });
+
+  test('should set terminal-theme in localStorage', () => {
+    applyTheme('amber');
+    assert.strictEqual(mockLocalStorage.store['terminal-theme'], 'amber');
+  });
+
+  test('should work with all predefined themes', () => {
+    THEMES.forEach(t => {
+      applyTheme(t.name);
+      assert.strictEqual(mockDocument.documentElement.attributes['data-theme'], t.name);
+      assert.strictEqual(mockLocalStorage.store['terminal-theme'], t.name);
+    });
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,17 @@
+export const THEMES = [
+  { name: 'green',   label: 'Green on Black (default)', swatch: '#39d353' },
+  { name: 'amber',   label: 'Amber on Black',           swatch: '#ffb000' },
+  { name: 'dracula', label: 'Dracula',                  swatch: '#bd93f9' },
+  { name: 'matrix',  label: 'Matrix',                   swatch: '#00ff41' },
+] as const;
+
+export type ThemeName = (typeof THEMES)[number]['name'];
+
+export function applyTheme(name: ThemeName) {
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('data-theme', name);
+  }
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('terminal-theme', name);
+  }
+}


### PR DESCRIPTION
Implemented unit tests for the `applyTheme` function. To achieve this in a restricted environment where `npm install` is not available, I utilized Node.js's built-in test runner (`node:test`) and the `--experimental-strip-types` flag. 

I refactored the theme logic and constants from `src/components/commands/Themes.tsx` into a new utility file `src/lib/theme.ts`. This not only made the logic easier to test but also added SSR safety (null checks for `document` and `localStorage`).

The tests mock the global `document` and `localStorage` objects to verify that the function has the expected side effects.

Key changes:
- Created `src/lib/theme.ts` containing `applyTheme`, `THEMES`, and `ThemeName`.
- Updated `src/components/commands/Themes.tsx` to use the shared logic and types.
- Created `src/lib/theme.test.ts` with comprehensive unit tests.
- Added a `test` script to `package.json`.
- Removed temporary development files.

---
*PR created automatically by Jules for task [15444068417794392054](https://jules.google.com/task/15444068417794392054) started by @joshuam1008*